### PR TITLE
Adding support for fill colors directly in JSON (TC 11 feature).

### DIFF
--- a/tests/test_thinkcell.py
+++ b/tests/test_thinkcell.py
@@ -141,6 +141,41 @@ class TestThinkcell(object):
                 ],
             }
         ]
+    def test_add_chart_with_fill(self):
+        tc = Thinkcell()
+        template = "example.pptx"
+        tc.add_template(template)
+        tc.add_chart(
+            template_name=template,
+            chart_name="Cool Name bro",
+            categories=["Alpha", "bravo"],
+            data=[[3, 4, datetime(2012, 9, 16, 0, 0)], [2, "adokf", 4]],
+            fill=["#70AD47", "#ED7D31"]
+        )
+        assert tc.charts == [
+            {
+                "template": "example.pptx",
+                "data": [
+                    {
+                        "name": "Cool Name bro",
+                        "table": [
+                            [None, {"string": "Alpha"}, {"string": "bravo"}],
+                            [],
+                            [
+                                {"number": 3, "fill": "#70AD47"},
+                                {"number": 4, "fill": "#70AD47"},
+                                {"date": "2012-09-16", "fill": "#70AD47"},
+                            ],
+                            [
+                                {"number": 2, "fill": "#ED7D31"},
+                                {"string": "adokf", "fill": "#ED7D31"},
+                                {"number": 4, "fill": "#ED7D31"},
+                            ],
+                        ],
+                    }
+                ],
+            }
+        ]
 
     def test_add_chart_from_dataframe(self):
         tc = Thinkcell()
@@ -181,6 +216,53 @@ class TestThinkcell(object):
                                 {"number": 50},
                                 {"number": 0.5},
                                 {"number": 16},
+                            ],
+                        ],
+                    },
+                ],
+            },
+        ]
+
+    def test_add_chart_from_dataframe_with_fill(self):
+        tc = Thinkcell()
+        template = "example.pptx"
+        dataframe = pd.DataFrame(
+            columns=["Company", "Employees", "Revenue", "Other"],
+            data=[["Apple", 200, 1.5, 10], ["Amazon", 100, 1.0, 12], ["Slack", 50, 0.5, 16]],
+        )
+        tc.add_template(template)
+        tc.add_chart_from_dataframe(
+            template_name=template,
+            chart_name="Cool Chart",
+            dataframe=dataframe,
+            fill=["#70AD47", "#ED7D31", "#4472C4"]
+        )
+        assert tc.charts == [
+            {
+                "template": "example.pptx",
+                "data": [
+                    {
+                        "name": "Cool Chart",
+                        "table": [
+                            [None, {"string": "Employees"}, {"string": "Revenue"}, {"string": "Other"}],
+                            [],
+                            [
+                                {"string": "Apple", "fill": "#70AD47"},
+                                {"number": 200, "fill": "#70AD47"},
+                                {"number": 1.5, "fill": "#70AD47"},
+                                {"number": 10, "fill": "#70AD47"},
+                            ],
+                            [
+                                {"string": "Amazon", "fill": "#ED7D31"},
+                                {"number": 100, "fill": "#ED7D31"},
+                                {"number": 1.0, "fill": "#ED7D31"},
+                                {"number": 12, "fill": "#ED7D31"},
+                            ],
+                            [
+                                {"string": "Slack", "fill": "#4472C4"},
+                                {"number": 50, "fill": "#4472C4"},
+                                {"number": 0.5, "fill": "#4472C4"},
+                                {"number": 16, "fill": "#4472C4"},
                             ],
                         ],
                     },

--- a/tests/test_thinkcell.py
+++ b/tests/test_thinkcell.py
@@ -141,6 +141,7 @@ class TestThinkcell(object):
                 ],
             }
         ]
+
     def test_add_chart_with_fill(self):
         tc = Thinkcell()
         template = "example.pptx"
@@ -150,7 +151,7 @@ class TestThinkcell(object):
             chart_name="Cool Name bro",
             categories=["Alpha", "bravo"],
             data=[[3, 4, datetime(2012, 9, 16, 0, 0)], [2, "adokf", 4]],
-            fill=["#70AD47", "#ED7D31"]
+            fill=["#70AD47", "#ED7D31"],
         )
         assert tc.charts == [
             {
@@ -182,7 +183,11 @@ class TestThinkcell(object):
         template = "example.pptx"
         dataframe = pd.DataFrame(
             columns=["Company", "Employees", "Revenue", "Other"],
-            data=[["Apple", 200, 1.5, 10], ["Amazon", 100, 1.0, 12], ["Slack", 50, 0.5, 16]],
+            data=[
+                ["Apple", 200, 1.5, 10],
+                ["Amazon", 100, 1.0, 12],
+                ["Slack", 50, 0.5, 16],
+            ],
         )
         tc.add_template(template)
         tc.add_chart_from_dataframe(
@@ -197,7 +202,12 @@ class TestThinkcell(object):
                     {
                         "name": "Cool Chart",
                         "table": [
-                            [None, {"string": "Employees"}, {"string": "Revenue"}, {"string": "Other"}],
+                            [
+                                None,
+                                {"string": "Employees"},
+                                {"string": "Revenue"},
+                                {"string": "Other"},
+                            ],
                             [],
                             [
                                 {"string": "Apple"},
@@ -218,9 +228,9 @@ class TestThinkcell(object):
                                 {"number": 16},
                             ],
                         ],
-                    },
+                    }
                 ],
-            },
+            }
         ]
 
     def test_add_chart_from_dataframe_with_fill(self):
@@ -228,14 +238,18 @@ class TestThinkcell(object):
         template = "example.pptx"
         dataframe = pd.DataFrame(
             columns=["Company", "Employees", "Revenue", "Other"],
-            data=[["Apple", 200, 1.5, 10], ["Amazon", 100, 1.0, 12], ["Slack", 50, 0.5, 16]],
+            data=[
+                ["Apple", 200, 1.5, 10],
+                ["Amazon", 100, 1.0, 12],
+                ["Slack", 50, 0.5, 16],
+            ],
         )
         tc.add_template(template)
         tc.add_chart_from_dataframe(
             template_name=template,
             chart_name="Cool Chart",
             dataframe=dataframe,
-            fill=["#70AD47", "#ED7D31", "#4472C4"]
+            fill=["#70AD47", "#ED7D31", "#4472C4"],
         )
         assert tc.charts == [
             {
@@ -244,7 +258,12 @@ class TestThinkcell(object):
                     {
                         "name": "Cool Chart",
                         "table": [
-                            [None, {"string": "Employees"}, {"string": "Revenue"}, {"string": "Other"}],
+                            [
+                                None,
+                                {"string": "Employees"},
+                                {"string": "Revenue"},
+                                {"string": "Other"},
+                            ],
                             [],
                             [
                                 {"string": "Apple", "fill": "#70AD47"},
@@ -265,15 +284,19 @@ class TestThinkcell(object):
                                 {"number": 16, "fill": "#4472C4"},
                             ],
                         ],
-                    },
+                    }
                 ],
-            },
+            }
         ]
 
     def test_add_chart_from_dataframe_invalid_dataframe(self):
         tc = Thinkcell()
         template = "example.pptx"
-        dataframe = [["Apple", 200, 1.5, 10], ["Amazon", 100, 1.0, 12], ["Slack", 50, 0.5, 16]]
+        dataframe = [
+            ["Apple", 200, 1.5, 10],
+            ["Amazon", 100, 1.0, 12],
+            ["Slack", 50, 0.5, 16],
+        ]
         tc.add_template(template)
         with pytest.raises(DataFrameError) as e_info:
             tc.add_chart_from_dataframe(
@@ -286,7 +309,11 @@ class TestThinkcell(object):
         tc = Thinkcell()
         template = "example.pptx"
         dataframe = pd.Series(
-            data=[["Apple", 200, 1.5, 10], ["Amazon", 100, 1.0, 12], ["Slack", 50, 0.5, 16]],
+            data=[
+                ["Apple", 200, 1.5, 10],
+                ["Amazon", 100, 1.0, 12],
+                ["Slack", 50, 0.5, 16],
+            ]
         )
         tc.add_template(template)
         with pytest.raises(DataFrameError) as e_info:
@@ -300,8 +327,7 @@ class TestThinkcell(object):
         tc = Thinkcell()
         template = "example.pptx"
         dataframe = pd.DataFrame(
-            columns=["Company"],
-            data=[["Apple"], ["Amazon"], ["Slack"]],
+            columns=["Company"], data=[["Apple"], ["Amazon"], ["Slack"]]
         )
         tc.add_template(template)
         with pytest.raises(DataFrameError) as e_info:
@@ -315,7 +341,7 @@ class TestThinkcell(object):
         tc = Thinkcell()
         template = "example.pptx"
         dataframe = pd.DataFrame(
-            columns=["Company", "Employees", "Revenue", "Other"],
+            columns=["Company", "Employees", "Revenue", "Other"]
         )
         tc.add_template(template)
         with pytest.raises(DataFrameError) as e_info:
@@ -330,22 +356,13 @@ class TestThinkcell(object):
         template = "example.pptx"
         tc.add_template(template)
         tc.add_textfield(
-            template_name=template,
-            field_name="Title",
-            text="A great slide",
+            template_name=template, field_name="Title", text="A great slide"
         )
         assert tc.charts == [
             {
                 "template": "example.pptx",
                 "data": [
-                    {
-                        "name": "Title",
-                        "table": [
-                            [
-                                {"string": "A great slide"},
-                            ],
-                        ],
-                    }
+                    {"name": "Title", "table": [[{"string": "A great slide"}]]}
                 ],
             }
         ]

--- a/thinkcell/thinkcell.py
+++ b/thinkcell/thinkcell.py
@@ -223,7 +223,7 @@ class Thinkcell(object):
             raise DataFrameError("You did not pass a valid Pandas DataFrame")
 
         try:
-            assert len(categories) > 1
+            assert len(categories) >= 1
             assert len(data)
         except AssertionError:
             raise DataFrameError(

--- a/thinkcell/thinkcell.py
+++ b/thinkcell/thinkcell.py
@@ -123,7 +123,9 @@ class Thinkcell(object):
         self.verify_template(template_name)
         self.charts.append({"template": template_name, "data": []})
 
-    def add_chart(self, template_name, chart_name, categories, data, fill=None):
+    def add_chart(
+        self, template_name, chart_name, categories, data, fill=None
+    ):
         """Adds a chart to the template object. 
 
         Parameters
@@ -190,7 +192,9 @@ class Thinkcell(object):
         if self.charts[-1]["template"] == template_name:
             self.charts[-1]["data"].append(chart_dict)
 
-    def add_chart_from_dataframe(self, template_name, chart_name, dataframe, fill=None):
+    def add_chart_from_dataframe(
+        self, template_name, chart_name, dataframe, fill=None
+    ):
         """Adds a chart based on a dataframe to the template object. 
 
         Parameters


### PR DESCRIPTION
With think-cell 11, we now have the feature to set the fill color with JSON. think-cell 11 is available on the **More Downloads** section at the bottom of the downloads page. The feature is described here: https://www.think-cell.com/en/product/whats-new.shtml?from=10&to=11 
![Screen Shot 2020-08-05 at 3 56 31 PM](https://user-images.githubusercontent.com/13022884/89471968-3d017b80-d734-11ea-91d8-b2bf058ef4d8.png)

In order for this feature to work, the template file needs to utilize the "Use Excel Fill on Top" option in the template chart's color scheme. https://www.think-cell.com/support/manual/basicconcepts.shtml#subsect:colorscheme 

![image](https://user-images.githubusercontent.com/13022884/89472495-72f32f80-d735-11ea-8ee5-922ec171c10a.png)

![Screen Shot 2020-08-05 at 3 59 34 PM](https://user-images.githubusercontent.com/13022884/89472227-c44eef00-d734-11ea-99e1-c65460481f04.png)

I added this feature by adding an optional argument named fill. If it is set to None, no "fill" element will be added to the JSON. 

So far, I have implemented this as a single color per Series, but it would be possible to expand filling each data point individually. In order to do this, I could expand the fill argument to also accept a 2d array that has len(series) lists each as long as that series data. This is not yet a required use case for me though. 

![Screen Shot 2020-08-05 at 4 00 04 PM](https://user-images.githubusercontent.com/13022884/89472233-c7e27600-d734-11ea-87db-6ed94bc85824.png)
